### PR TITLE
Add rust-toolchain file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,6 @@ jobs:
       - name: Install tools
         run: |
           rustup update          --no-self-update
-          rustup install nightly --no-self-update
-          rustup component add clippy  --toolchain nightly
-          rustup component add rustfmt --toolchain nightly
           export CARGO_TARGET_DIR="$(mktemp -d)"
           cargo install cargo-dylint dylint-link || true
           cargo install cargo-license            || true

--- a/elaborate/tests/ci.rs
+++ b/elaborate/tests/ci.rs
@@ -18,7 +18,7 @@ fn initialize() {
 #[test]
 fn check_all_features() {
     Command::new("cargo")
-        .args(["+nightly", "check", "--all-features"])
+        .args(["check", "--all-features"])
         .env("RUSTFLAGS", "--deny=warnings")
         .assert()
         .success();
@@ -30,13 +30,7 @@ fn clippy() {
         // smoelius: Remove `CARGO` environment variable to work around:
         // https://github.com/rust-lang/rust/pull/131729
         .env_remove("CARGO")
-        .args([
-            "+nightly",
-            "clippy",
-            "--all-targets",
-            "--",
-            "--deny=warnings",
-        ])
+        .args(["clippy", "--all-targets", "--", "--deny=warnings"])
         .assert()
         .success();
 }

--- a/generate/src/lib.rs
+++ b/generate/src/lib.rs
@@ -23,7 +23,6 @@ use util::{
     FunctionExt, GenericBoundsExt, TokenExt, TokensExt,
 };
 
-pub const TOOLCHAIN: &str = "nightly-2024-10-22";
 pub const COMMIT: &str = "4392847410ddd67f6734dd9845f9742ff9e85c83";
 
 #[cfg_attr(dylint_lib = "general", allow(abs_home_path))]
@@ -825,7 +824,6 @@ fn disallowable_qualified_fn(
 #[cfg(target_os = "linux")]
 #[cfg(test)]
 mod test {
-    use once_cell::sync::Lazy;
     use similar_asserts::SimpleDiff;
     use std::{
         env::var,
@@ -840,15 +838,6 @@ mod test {
     const RUST_DIR: &str = "checkouts/rust";
     const SUBMODULES: &[&str] = &["library/backtrace", "library/stdarch"];
     const TARGET: &str = "x86_64-unknown-linux-gnu";
-
-    static TOOLCHAIN: Lazy<&str> = Lazy::new(|| {
-        let status = Command::new("rustup")
-            .args(["toolchain", "install", super::TOOLCHAIN, "--no-self-update"])
-            .status()
-            .unwrap();
-        assert!(status.success());
-        super::TOOLCHAIN
-    });
 
     #[test]
     fn generated_is_current() {
@@ -872,11 +861,7 @@ mod test {
     fn version_commit() {
         let short_commit = &super::COMMIT[..9];
         let pat = format!("({short_commit} ");
-        let output = Command::new("rustc")
-            .arg("--version")
-            .env("RUSTUP_TOOLCHAIN", *TOOLCHAIN)
-            .output()
-            .unwrap();
+        let output = Command::new("rustc").arg("--version").output().unwrap();
         let stdout = std::str::from_utf8(&output.stdout).unwrap();
         assert!(
             stdout.contains(&pat),
@@ -934,7 +919,6 @@ mod test {
                 "unstable-options",
                 "--output-format=json",
             ])
-            .env("RUSTUP_TOOLCHAIN", *TOOLCHAIN)
             .current_dir(Path::new(RUST_DIR).join("library/std"))
             .status()
             .unwrap();

--- a/generate/tests/ci.rs
+++ b/generate/tests/ci.rs
@@ -2,16 +2,9 @@ use assert_cmd::Command;
 
 #[test]
 fn hack_feature_powerset_udeps() {
-    Command::new("rustup")
+    Command::new("cargo")
         .env("RUSTFLAGS", "-D warnings")
-        .args([
-            "run",
-            "nightly",
-            "cargo",
-            "hack",
-            "--feature-powerset",
-            "udeps",
-        ])
+        .args(["hack", "--feature-powerset", "udeps"])
         .assert()
         .success();
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-10-22"


### PR DESCRIPTION
Adds a rust-toolchain file with the channel the `generate` package uses.

One downside to this approach is that we no longer test with `stable`.