### PR TITLE
Reset `generate` version to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generate"
-version = "1.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate"
-version = "1.2.0"
+version = "0.1.0"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
Since `generate` is not published, it does not make sense to bump its version.