### PR TITLE
Testing improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,6 @@ name = "elaborate"
 version = "2.2.0"
 dependencies = [
  "anyhow",
- "assert_cmd",
  "tempfile",
 ]
 
@@ -236,7 +235,6 @@ name = "generate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assert_cmd",
  "itertools",
  "public-api",
  "regex",

--- a/elaborate/Cargo.toml
+++ b/elaborate/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.89"
 anyhow = "1.0"
 
 [dev-dependencies]
-assert_cmd = "2.2"
 tempfile = "3.27"
 
 # smoelius: If you add features below, please also add them near the top of src/lib.rs.

--- a/elaborate/tests/ci.rs
+++ b/elaborate/tests/ci.rs
@@ -1,13 +1,13 @@
-use assert_cmd::Command;
-use std::path::Path;
+use std::{path::Path, process::Command};
 
 #[test]
 fn ci() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
 
-    Command::new("cargo")
+    let status = Command::new("cargo")
         .current_dir(workspace_root)
         .args(["run", "--manifest-path", "ci/Cargo.toml"])
-        .assert()
-        .success();
+        .status()
+        .unwrap();
+    assert!(status.success());
 }

--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -15,7 +15,6 @@ serde_json = "1.0"
 tempfile = "3.27"
 
 [dev-dependencies]
-assert_cmd = "2.2"
 similar-asserts = "2.0"
 
 [lints]

--- a/generate/tests/ci.rs
+++ b/generate/tests/ci.rs
@@ -1,10 +1,11 @@
-use assert_cmd::Command;
+use std::process::Command;
 
 #[test]
 fn hack_feature_powerset_udeps() {
-    Command::new("cargo")
+    let status = Command::new("cargo")
         .env("RUSTFLAGS", "-D warnings")
-        .args(["hack", "--feature-powerset", "udeps"])
-        .assert()
-        .success();
+        .args(["hack", "--feature-powerset", "udeps", "--all-targets"])
+        .status()
+        .unwrap();
+    assert!(status.success());
 }


### PR DESCRIPTION
- Don't capture test output
- Run `cargo udeps` with `--all-targets`